### PR TITLE
Add Go Freek 2026 Tauranga photography page

### DIFF
--- a/__tests__/nav/Header.test.tsx
+++ b/__tests__/nav/Header.test.tsx
@@ -46,6 +46,7 @@ describe('Header', () => {
 
       fireEvent.mouseEnter(photographyButton.parentElement!);
       expect(await screen.findByText('Portraits')).toBeInTheDocument();
+      expect(screen.getByText('Go Freek 2026 Tauranga')).toBeInTheDocument();
 
       fireEvent.mouseLeave(photographyButton.parentElement!);
       act(() => {

--- a/__tests__/photography/pages.test.tsx
+++ b/__tests__/photography/pages.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
 import PhotographyPage from '../../src/app/photography/page';
+import GoFreek2026TaurangaPage from '../../src/app/photography/go-freek-2026-tauranga/page';
 import PortraitsPage from '../../src/app/photography/portraits/page';
 
 const requiredEnv = jest.fn();
@@ -75,5 +76,16 @@ describe('Photography server pages', () => {
     render(await PortraitsPage());
 
     expect(screen.getByText('gallery:demo-cloud:2')).toBeInTheDocument();
+  });
+
+  it('requests the go freek album and renders empty state when no images exist', async () => {
+    getCloudinaryPhotosByFolder.mockResolvedValue([]);
+
+    render(await GoFreek2026TaurangaPage());
+
+    expect(getCloudinaryPhotosByFolder).toHaveBeenCalledWith(
+      '2026-04-26-go-freek'
+    );
+    expect(screen.getByText('No photos available yet.')).toBeInTheDocument();
   });
 });

--- a/src/app/photography/go-freek-2026-tauranga/page.tsx
+++ b/src/app/photography/go-freek-2026-tauranga/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next';
+import { requiredEnv } from '@/app/utils/cloudinary';
+import { getCloudinaryPhotosByFolder } from '@/app/utils/photography';
+import PhotographyGallery from '@/components/PhotographyGallery';
+
+export const metadata: Metadata = {
+  title: 'Go Freek 2026 Tauranga | FlyingDolly',
+  description:
+    'Photography highlights from Go Freek 2026 Tauranga, curated by FlyingDolly.',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function GoFreek2026TaurangaPage() {
+  const cloudName = requiredEnv('NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME');
+  const images = await getCloudinaryPhotosByFolder('2026-04-26-go-freek');
+
+  return (
+    <main className="min-h-screen bg-gray-950 px-6 pb-20 pt-32 text-white lg:px-8">
+      <section className="mx-auto max-w-7xl">
+        <div className="mb-10 max-w-3xl">
+          <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+            Go Freek 2026 Tauranga
+          </h1>
+          <p className="mt-4 text-base text-gray-300 sm:text-lg">
+            A gallery showcasing Go Freek 2026 Tauranga photography.
+          </p>
+        </div>
+
+        {images.length === 0 ? (
+          <div className="rounded-xl border border-gray-700 bg-gray-900/70 p-8">
+            <p className="text-lg font-medium text-white">
+              No photos available yet.
+            </p>
+            <p className="mt-2 text-sm text-gray-300">
+              Upload images to your configured Cloudinary folder to populate
+              this gallery.
+            </p>
+          </div>
+        ) : (
+          <PhotographyGallery images={images} cloudName={cloudName} />
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/utils/navigation-links.ts
+++ b/src/app/utils/navigation-links.ts
@@ -22,6 +22,11 @@ export const NavigationLinks: NavLink[] = [
         href: '/photography/portraits',
         description: 'Professional portrait sessions',
       },
+      {
+        name: 'Go Freek 2026 Tauranga',
+        href: '/photography/go-freek-2026-tauranga',
+        description: 'Event highlights from Go Freek 2026',
+      },
     ],
   },
   // { name: 'About', href: '/about' },


### PR DESCRIPTION
Summary:
- add a new photography route at /photography/go-freek-2026-tauranga
- load gallery images from Cloudinary album 2026-04-26-go-freek
- add the new page to the Photography menu dropdown
- extend tests to cover the new route and nav link

Testing:
- npm run lint
- npm run build
- npm test