### PR TITLE
Add GA4 phase 1 journey tracking

### DIFF
--- a/__tests__/components/ContactForm.test.tsx
+++ b/__tests__/components/ContactForm.test.tsx
@@ -6,6 +6,7 @@ import ContactForm from '../../src/components/ContactForm';
 const addFlashMessage = jest.fn();
 const checkEmailLimitCookie = jest.fn();
 const setEmailLimitCookie = jest.fn();
+const trackGenerateLead = jest.fn();
 
 jest.mock('../../src/hooks/useFlashMessages', () => ({
   __esModule: true,
@@ -15,6 +16,10 @@ jest.mock('../../src/hooks/useFlashMessages', () => ({
 jest.mock('../../src/app/utils/cookies-functions', () => ({
   setEmailLimitCookie: (...args: unknown[]) => setEmailLimitCookie(...args),
   checkEmailLimitCookie: (...args: unknown[]) => checkEmailLimitCookie(...args),
+}));
+
+jest.mock('../../src/app/utils/analytics', () => ({
+  trackGenerateLead: (...args: unknown[]) => trackGenerateLead(...args),
 }));
 
 describe('ContactForm', () => {
@@ -97,6 +102,14 @@ describe('ContactForm', () => {
         message: 'Your message has been sent successfully!',
       })
     );
+    expect(trackGenerateLead).toHaveBeenNthCalledWith(1, {
+      source: 'contact_form',
+      result: 'attempt',
+    });
+    expect(trackGenerateLead).toHaveBeenNthCalledWith(2, {
+      source: 'contact_form',
+      result: 'success',
+    });
 
     expect(fetchMock).toHaveBeenCalledWith('/api/send-email', {
       method: 'POST',
@@ -134,6 +147,14 @@ describe('ContactForm', () => {
           'There was an error sending your message. Please try again later.',
       })
     );
+    expect(trackGenerateLead).toHaveBeenNthCalledWith(1, {
+      source: 'contact_form',
+      result: 'attempt',
+    });
+    expect(trackGenerateLead).toHaveBeenNthCalledWith(2, {
+      source: 'contact_form',
+      result: 'error',
+    });
     expect(setEmailLimitCookie).not.toHaveBeenCalled();
   });
 
@@ -157,6 +178,14 @@ describe('ContactForm', () => {
           'There was an error sending your message. Please try again later.',
       })
     );
+    expect(trackGenerateLead).toHaveBeenNthCalledWith(1, {
+      source: 'contact_form',
+      result: 'attempt',
+    });
+    expect(trackGenerateLead).toHaveBeenNthCalledWith(2, {
+      source: 'contact_form',
+      result: 'error',
+    });
     expect(setEmailLimitCookie).not.toHaveBeenCalled();
   });
 

--- a/__tests__/components/FooterAndContactUs.test.tsx
+++ b/__tests__/components/FooterAndContactUs.test.tsx
@@ -4,6 +4,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import ContactUsButton from '../../src/components/ContactUsButton';
 import FooterSection from '../../src/components/FooterSection';
 
+const trackGenerateLead = jest.fn();
+
+jest.mock('../../src/app/utils/analytics', () => ({
+  trackGenerateLead: (...args: unknown[]) => trackGenerateLead(...args),
+}));
+
 describe('FooterSection', () => {
   it('renders social links that open safely in a new tab', () => {
     render(<FooterSection />);
@@ -29,6 +35,10 @@ describe('FooterSection', () => {
 });
 
 describe('ContactUsButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('scrolls to the contact section when clicked', () => {
     const scrollIntoView = jest.fn();
     const section = document.createElement('section');
@@ -40,6 +50,10 @@ describe('ContactUsButton', () => {
     fireEvent.click(screen.getByRole('button', { name: /book a free call/i }));
 
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(trackGenerateLead).toHaveBeenCalledWith({
+      source: 'cta_button',
+      location: 'unknown',
+    });
     section.remove();
   });
 

--- a/__tests__/nav/Header.test.tsx
+++ b/__tests__/nav/Header.test.tsx
@@ -3,7 +3,17 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import Header from '../../src/components/nav/Header';
 
+const trackSelectContent = jest.fn();
+
+jest.mock('../../src/app/utils/analytics', () => ({
+  trackSelectContent: (...args: unknown[]) => trackSelectContent(...args),
+}));
+
 describe('Header', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('hides the nav menu by default on mobile', () => {
     render(<Header />);
     const menu = screen.getByRole('list');
@@ -69,5 +79,10 @@ describe('Header', () => {
 
     fireEvent.click(screen.getByRole('link', { name: 'Home' }));
     expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(trackSelectContent).toHaveBeenCalledWith({
+      source: 'header_nav',
+      destination: '/',
+      label: 'Home',
+    });
   });
 });

--- a/__tests__/nav/Header.test.tsx
+++ b/__tests__/nav/Header.test.tsx
@@ -71,6 +71,23 @@ describe('Header', () => {
     }
   });
 
+  it('tracks analytics for a photography flyout sub-link click', async () => {
+    render(<Header />);
+
+    const photographyButton = screen.getByRole('button', {
+      name: /photography/i,
+    });
+
+    fireEvent.mouseEnter(photographyButton.parentElement!);
+    fireEvent.click(await screen.findByRole('link', { name: 'Portraits' }));
+
+    expect(trackSelectContent).toHaveBeenCalledWith({
+      source: 'header_nav',
+      destination: '/photography/portraits',
+      label: 'Portraits',
+    });
+  });
+
   it('closes the mobile menu after a menu link is clicked', () => {
     render(<Header />);
     const button = screen.getByRole('button', { name: /open main menu/i });

--- a/__tests__/utils/analytics.test.ts
+++ b/__tests__/utils/analytics.test.ts
@@ -1,0 +1,30 @@
+import { trackGenerateLead, trackSelectContent } from '../../src/app/utils/analytics';
+
+describe('analytics helper', () => {
+  afterEach(() => {
+    delete (window as Window & { gtag?: unknown }).gtag;
+  });
+
+  it('sends select_content when gtag is available', () => {
+    const gtag = jest.fn();
+    (window as Window & { gtag?: typeof gtag }).gtag = gtag;
+
+    trackSelectContent({
+      source: 'header_nav',
+      destination: '/photography',
+      label: 'Photography',
+    });
+
+    expect(gtag).toHaveBeenCalledWith('event', 'select_content', {
+      source: 'header_nav',
+      destination: '/photography',
+      label: 'Photography',
+    });
+  });
+
+  it('does not throw when gtag is unavailable', () => {
+    expect(() =>
+      trackGenerateLead({ source: 'contact_form', result: 'attempt' })
+    ).not.toThrow();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,7 +99,7 @@ export default function Home() {
                 something amazing together.
               </p>
 
-              <ContactUsButton />
+              <ContactUsButton location="mid_page" />
             </div>
 
             <div className="flex flex-wrap items-start justify-end gap-6 sm:gap-8 lg:contents">

--- a/src/app/utils/analytics.ts
+++ b/src/app/utils/analytics.ts
@@ -1,0 +1,42 @@
+'use client';
+
+type EventParams = Record<string, string | number | boolean | undefined>;
+
+type GtagFn = (
+  command: 'event',
+  eventName: string,
+  eventParams?: EventParams
+) => void;
+
+type WindowWithGtag = Window & {
+  gtag?: GtagFn;
+};
+
+const sendEvent = (eventName: string, eventParams: EventParams) => {
+  if (typeof window === 'undefined') return;
+
+  const { gtag } = window as WindowWithGtag;
+  if (typeof gtag !== 'function') return;
+
+  gtag('event', eventName, eventParams);
+};
+
+export type SelectContentParams = {
+  source: string;
+  destination: string;
+  label: string;
+};
+
+export type GenerateLeadParams = {
+  source: string;
+  location?: string;
+  result?: 'attempt' | 'success' | 'error';
+};
+
+export const trackSelectContent = (params: SelectContentParams) => {
+  sendEvent('select_content', params);
+};
+
+export const trackGenerateLead = (params: GenerateLeadParams) => {
+  sendEvent('generate_lead', params);
+};

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -6,6 +6,7 @@ import Input from './Input';
 import TextArea from './TextArea';
 import useFlashMessages from '@/hooks/useFlashMessages';
 import ContactSubmitButton from './ContactSubmitButton';
+import { trackGenerateLead } from '@/app/utils/analytics';
 import {
   setEmailLimitCookie,
   checkEmailLimitCookie,
@@ -64,6 +65,7 @@ export default function ContactForm() {
       return;
     }
     setIsSending(true);
+    trackGenerateLead({ source: 'contact_form', result: 'attempt' });
 
     try {
       const res = await fetch('/api/send-email', {
@@ -77,6 +79,7 @@ export default function ContactForm() {
           type: 'success',
           message: 'Your message has been sent successfully!',
         });
+        trackGenerateLead({ source: 'contact_form', result: 'success' });
         setIsFormSent(true);
         setEmailLimitCookie(60); // Set cookie for 60 minutes
       } else {
@@ -85,6 +88,7 @@ export default function ContactForm() {
           message:
             'There was an error sending your message. Please try again later.',
         });
+        trackGenerateLead({ source: 'contact_form', result: 'error' });
         console.error(result.error);
       }
     } catch (error) {
@@ -93,6 +97,7 @@ export default function ContactForm() {
         message:
           'There was an error sending your message. Please try again later.',
       });
+      trackGenerateLead({ source: 'contact_form', result: 'error' });
       console.error(error);
     } finally {
       setIsSending(false);

--- a/src/components/ContactUsButton.tsx
+++ b/src/components/ContactUsButton.tsx
@@ -1,9 +1,17 @@
 'use client';
 
 import CTAButton from './CTAButton';
+import { trackGenerateLead } from '@/app/utils/analytics';
 
-export default function ContactUsButton() {
+type ContactUsButtonProps = {
+  location?: string;
+};
+
+export default function ContactUsButton({
+  location = 'unknown',
+}: ContactUsButtonProps) {
   const handleContactUsClick = () => {
+    trackGenerateLead({ source: 'cta_button', location });
     const contactForm = document.getElementById('contact-form-section');
     if (contactForm) {
       contactForm.scrollIntoView({ behavior: 'smooth' });

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -31,7 +31,7 @@ export default function HeroSection() {
                 handle the tech so you can focus on the vision.
               </h2>
             </div>
-            <ContactUsButton />
+            <ContactUsButton location="hero" />
           </div>
 
           <div className="mb-12 flex items-center justify-center opacity-25">

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import Image from 'next/image';
 import { AppConstants } from '@/app/utils/app-constants';
 import Link from 'next/link';
+import { trackSelectContent } from '@/app/utils/analytics';
 import { NavigationLinks, type NavLink } from '@/app/utils/navigation-links';
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
@@ -64,7 +65,14 @@ function NavFlyout({
                 <Link
                   href={item.href}
                   className="block font-semibold text-white"
-                  onClick={onItemClick}
+                  onClick={() => {
+                    trackSelectContent({
+                      source: 'header_nav',
+                      destination: item.href,
+                      label: item.name,
+                    });
+                    onItemClick();
+                  }}
                 >
                   {item.name}
                   <span className="absolute inset-0" />
@@ -141,7 +149,14 @@ export default function Header() {
                     <Link
                       href={link.href}
                       className="font-semibold leading-6 text-white transition-colors hover:text-green-400"
-                      onClick={() => setIsMenuOpen(false)}
+                      onClick={() => {
+                        trackSelectContent({
+                          source: 'header_nav',
+                          destination: link.href,
+                          label: link.name,
+                        });
+                        setIsMenuOpen(false);
+                      }}
                     >
                       {link.name}
                     </Link>


### PR DESCRIPTION
Summary:
- add a shared analytics helper for GA4 event dispatch
- instrument Book a free call CTA clicks with generate_lead plus source/location
- instrument header navigation clicks including photography flyout links with select_content
- instrument contact form attempt plus success/error outcomes with generate_lead
- add tests for analytics helper and tracking behavior

Why this PR:
- this is a minimal, high-signal first step to track the user journey from intent to contact outcome
- it creates a reusable event API for later phased analytics expansion

Validation:
- npm run lint
- npm run build
- npm test